### PR TITLE
Fix github actions, fix package script, linter cleanups

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -47,7 +47,7 @@ jobs:
       uses: paketo-buildpacks/github-config/actions/release/create@main
       with:
         repo: ${{ github.repository }}
-        token: ${{ github.token }}
+        token: ${{ secrets.MS_BOT_GITHUB_TOKEN }}
         tag_name: v${{ steps.tag.outputs.tag }}
         target_commitish: ${{ github.sha }}
         name: v${{ steps.tag.outputs.tag }}
@@ -66,3 +66,4 @@ jobs:
               "content_type": "application/gzip"
             }
           ]
+          

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,17 +1,16 @@
 api = "0.2"
 
 [buildpack]
-  id = "io.avarteqgmbh.buildpacks.git-ssh"
-  name = "GIT SSH buildpack"
-  version = "0.5.4"
-  homepage = "https://github.com/avarteqgmbh/git-ssh-buildpack"
+id = "io.avarteqgmbh.buildpacks.git-ssh"
+name = "GIT SSH buildpack"
+homepage = "https://github.com/avarteqgmbh/git-ssh-buildpack"
 
 [metadata]
-  include_files = ["bin/build", "bin/detect", "buildpack.toml", "go.mod", "go.sum"]
-  pre_package = "./scripts/build.sh"
+include-files = ["bin/build", "bin/detect", "buildpack.toml"]
+pre-package = "./scripts/build.sh"
 
 [[stacks]]
-  id = "io.buildpacks.stacks.bionic"
+id = "io.buildpacks.stacks.bionic"
 
 [[stacks]]
-  id = "org.cloudfoundry.stacks.cflinuxfs3"
+id = "org.cloudfoundry.stacks.cflinuxfs3"

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -31,7 +31,7 @@ func main() {
 }
 
 func RunBuild(context build.Build, runner sshagent.Runner) (int, error) {
-	context.Logger.FirstLine(context.Logger.PrettyIdentity(context.Buildpack))
+	context.Logger.Title(context.Buildpack)
 
 	err := sshagent.Contribute(context, runner)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,9 @@ require (
 	github.com/paketo-buildpacks/packit v0.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/sclevine/spec v1.4.0
-	golang.org/x/net v0.0.0-20210222171744-9060382bd457 // indirect
+	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 // indirect
 	golang.org/x/oauth2 v0.0.0-20210220000619-9bb904979d93 // indirect
-	golang.org/x/sys v0.0.0-20210223085322-b80eb88b80d2 // indirect
+	golang.org/x/sys v0.0.0-20210303074136-134d130e1a04 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -436,6 +436,8 @@ golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210222171744-9060382bd457 h1:hMm9lBjyNLe/c9C6bElQxp4wsrleaJn1vXMZIQkNN44=
 golang.org/x/net v0.0.0-20210222171744-9060382bd457/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
@@ -504,6 +506,8 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210223085322-b80eb88b80d2 h1:13AoIkn4ArHk7oLuacugPQZZRRxNXUSnuyNY4TVUJr8=
 golang.org/x/sys v0.0.0-20210223085322-b80eb88b80d2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210303074136-134d130e1a04 h1:cEhElsAv9LUt9ZUUocxzWe05oFLVd+AA2nstydTeI8g=
+golang.org/x/sys v0.0.0-20210303074136-134d130e1a04/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/sshagent/sshagent.go
+++ b/sshagent/sshagent.go
@@ -42,7 +42,7 @@ func Contribute(context build.Build, runner Runner) error {
 		return errors.New("No GIT_SSH_KEY environment variable found")
 	}
 
-	layer.Logger.SubsequentLine("Starting SSH agent")
+	layer.Logger.Body("Starting SSH agent")
 	err = runner.Run(ioutil.Discard, os.Stderr, nil, "ssh-agent", "-a", SockAddress)
 	if err != nil {
 		layer.Logger.HeaderError("Failed to start ssh-agent [%v]", err)
@@ -71,7 +71,7 @@ func Contribute(context build.Build, runner Runner) error {
 			if exitErr, ok := err.(*exec.ExitError); ok {
 				if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
 					if status.ExitStatus() > 1 {
-						layer.Logger.Error("Failed to authorize with [%s]", host)
+						layer.Logger.BodyError("Failed to authorize with [%s]", host)
 						return err
 					}
 				}
@@ -88,7 +88,7 @@ func Contribute(context build.Build, runner Runner) error {
 	}
 
 	if err := layer.Contribute(sshAgentHelperLayerContributor, flags(dependency)...); err != nil {
-		layer.Logger.Error("Failed to contribute helper layer [%v]", err)
+		layer.Logger.BodyError("Failed to contribute helper layer [%v]", err)
 		return err
 	}
 


### PR DESCRIPTION
- Build script now works properly.
- [version] field in "buildpack.toml" is now properly changed by build script (only in binaries), so it was removed again from sources.
- Stack "org.cloudfoundry.stacks.cflinuxfs3" is now not required for build process (but was left for compatibility with outdated cloudfoundry's packager).

P.S.
This commit cannot be safely merged with "master" branch without changes in "github actions".